### PR TITLE
CSRF Token is required for non-GET request links

### DIFF
--- a/src/method.js
+++ b/src/method.js
@@ -17,6 +17,13 @@ document.addEventListener('click', function(event) {
     form.method = 'POST';
     form.action = element.getAttribute('href');
     form.style.display = 'none';
+    
+    var csrfToken = document.createElement('input');
+    csrfToken.setAttribute('type', 'hidden');
+    csrfToken.setAttribute('name', CSRF.param());
+    csrfToken.setAttribute('value', CSRF.token());
+    form.appendChild(csrfToken);
+
 
     if (method != 'POST') {
       input = document.createElement('input');


### PR DESCRIPTION
If you were to do a `link_to "Some Link", some_path, method: :delete` for example, it would previously fail as there was no CSRF token sent over as well. This fixes that.
