### PR TITLE
Rails Controller not properly recognizing LiteAjax requests as "JS"

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/liteajax.js
+++ b/lib/assets/javascripts/vanilla-ujs/liteajax.js
@@ -13,6 +13,12 @@ var LiteAjax = (function () {
     }
 
     options = options || {};
+    
+    if(!options.accepts) {
+      options.accepts = 'text/javascript, application/javascript, ' + 
+                        'application/ecmascript, application/x-ecmascript';
+    }
+
     url = url || options.url || location.href || '';
     var data = options.data;
 
@@ -46,6 +52,7 @@ var LiteAjax = (function () {
 
     xhr.open(options.method || 'GET', url);
     xhr.setRequestHeader('X-Requested-With', 'XmlHttpRequest');
+    xhr.setRequestHeader('Accept', '*/*;q=0.5, ' + options.accepts);
 
     if(options.json) {
       xhr.setRequestHeader('Content-type', 'application/json');


### PR DESCRIPTION
LiteAjax does not set an Accept header, and thus does not trigger Rails' request identification mechanism. This causes remote actions to be recognized as "\*/\*" rather than "JS", which causes the format to be wrong, and the wrong template to be loaded, as well as an issue with redirect after destroy actions.

The attached PR fixes this, but I would appreciate some guidance as to whether it goes too far. Are there cases in this library (or alternate uses of LiteAjax) where a different response would be needed? Is this too strong a preference for one usage for it to become the default, as I have it here?

Thanks,

Walter