### PR TITLE
Missing var definitions for strict mode

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/form.js
+++ b/lib/assets/javascripts/vanilla-ujs/form.js
@@ -3,9 +3,9 @@ document.addEventListener('submit', function(event) {
   var form = event.target;
 
   if (matches.call(form, 'form[data-remote]')) {
-    url = form.action;
-    method = form.method || form.getAttribute('data-method').toUpperCase() || 'POST';
-    data = new FormData(form);
+    var url = form.action;
+    var method = (form.method || form.getAttribute('data-method') || 'POST').toUpperCase();
+    var data = new FormData(form);
 
     if (CSRF.param() && CSRF.token()) {
       data[CSRF.param()] = CSRF.token();

--- a/lib/assets/javascripts/vanilla-ujs/liteajax.js
+++ b/lib/assets/javascripts/vanilla-ujs/liteajax.js
@@ -25,7 +25,7 @@ var LiteAjax = (function () {
     var xhr = new XMLHttpRequest();
 
     xhr.addEventListener('load', function () {
-      responseType = xhr.getResponseHeader('content-type');
+      var responseType = xhr.getResponseHeader('content-type');
       if(responseType === 'text/javascript; charset=utf-8') {
         eval(xhr.response);
       }


### PR DESCRIPTION
With strict mode enabled there were a couple of exceptions being raised from missing `var` definitions.

Also made one minor change to the way the `method` variable is defined to uppercase the final string instead of a method that may return `null` and subsequently raise an exception.