### PR TITLE
Correct ajax complete event

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/liteajax.js
+++ b/lib/assets/javascripts/vanilla-ujs/liteajax.js
@@ -30,7 +30,7 @@ var LiteAjax = (function () {
         eval(xhr.response);
       }
 
-      var event = new CustomEvent('ajaxComplete', {detail: xhr});
+      var event = new CustomEvent('ajax:complete', {detail: xhr});
       document.dispatchEvent(event);
     });
 

--- a/test/form.spec.js
+++ b/test/form.spec.js
@@ -58,11 +58,11 @@ describe('Form methods', function () {
             path: '/xhr'
           });
           
-          doc().removeEventListener('ajaxComplete', handler);
+          doc().removeEventListener('ajax:complete', handler);
           done();
         };
         
-        doc().addEventListener('ajaxComplete', handler);
+        doc().addEventListener('ajax:complete', handler);
         
         click(submit);
         

--- a/test/method.spec.js
+++ b/test/method.spec.js
@@ -74,11 +74,11 @@ describe('Link methods', function () {
             path: '/xhr'
           });
 
-          doc().removeEventListener('ajaxComplete', handler);
+          doc().removeEventListener('ajax:complete', handler);
           done();
         };
 
-        doc().addEventListener('ajaxComplete', handler);
+        doc().addEventListener('ajax:complete', handler);
 
         click(a);
       });


### PR DESCRIPTION
UJS fires ajax:complete, not ajaxComplete when the XHR request is finished.

See: https://github.com/rails/jquery-ujs/wiki/ajax