### PR TITLE
Only handle left click events.

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/method.js
+++ b/lib/assets/javascripts/vanilla-ujs/method.js
@@ -1,6 +1,11 @@
 document.addEventListener('click', function(event) {
   var element, url, method, data, handler;
 
+  // Only left click allowed. Firefox triggers click event on right click/contextmenu.
+  if (event.button !== 0) {
+    return;
+  }
+
   element = event.target;
 
   if (matches.call(element, 'a[data-method]')) {


### PR DESCRIPTION
It appears to be a bug in Firefox causing the click event to be triggered on right-click.
See: https://bugzilla.mozilla.org/show_bug.cgi?id=184051