### PR TITLE
target support for LiteAjax

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/form.js
+++ b/lib/assets/javascripts/vanilla-ujs/form.js
@@ -11,7 +11,7 @@ document.addEventListener('submit', function(event) {
       data[CSRF.param()] = CSRF.token();
     }
 
-    if (LiteAjax.ajax({ url: url, method: method, data: data })){
+    if (LiteAjax.ajax({ url: url, method: method, data: data, target: form })){
       event.preventDefault();
     } else {
       return true;

--- a/lib/assets/javascripts/vanilla-ujs/liteajax.js
+++ b/lib/assets/javascripts/vanilla-ujs/liteajax.js
@@ -21,7 +21,7 @@ var LiteAjax = (function () {
 
     url = url || options.url || location.href || '';
     var data = options.data;
-
+    var target = options.target || document;
     var xhr = new XMLHttpRequest();
 
     xhr.addEventListener('load', function () {
@@ -30,8 +30,8 @@ var LiteAjax = (function () {
         eval(xhr.response);
       }
 
-      var event = new CustomEvent('ajax:complete', {detail: xhr});
-      document.dispatchEvent(event);
+      var event = new CustomEvent('ajax:complete', {detail: xhr, bubbles: true});
+      target.dispatchEvent(event);
     });
 
     if (typeof options.success == 'function')
@@ -59,8 +59,8 @@ var LiteAjax = (function () {
       data = JSON.stringify(data);
     }
 
-    var beforeSend = new CustomEvent('ajax:before', {detail: xhr});
-    document.dispatchEvent(beforeSend);
+    var beforeSend = new CustomEvent('ajax:before', {detail: xhr, bubbles: true});
+    target.dispatchEvent(beforeSend);
     xhr.send(data);
 
     return xhr;

--- a/lib/assets/javascripts/vanilla-ujs/method.js
+++ b/lib/assets/javascripts/vanilla-ujs/method.js
@@ -23,7 +23,7 @@ document.addEventListener('click', function(event) {
       handler = submit;
     }
 
-    if (handler({ url: url, method: method, data: data })) {
+    if (handler({ url: url, method: method, data: data, target: element })) {
       event.preventDefault();
     } else {
       return true;

--- a/test/form.spec.js
+++ b/test/form.spec.js
@@ -47,7 +47,39 @@ describe('Form methods', function () {
         form.setAttribute('action', '/xhr');
         form.setAttribute('data-remote', 'true');
       });
-      
+
+      it('calls ajax:before event on form with bubbling enabled', function (done) {
+        var handler = function (event) {
+          expect(event.target).to.equal(form);
+          expect(event.bubbles).to.equal(true);
+
+          doc().removeEventListener('ajax:before', handler);
+          done();
+        };
+
+        doc().addEventListener('ajax:before', handler);
+
+        click(submit);
+
+        expect(submitForm.called).to.be.true;
+      });
+
+      it('calls ajax:complete event on form with bubbling enabled', function (done) {
+        var handler = function (event) {
+          expect(event.target).to.equal(form);
+          expect(event.bubbles).to.equal(true);
+
+          doc().removeEventListener('ajax:complete', handler);
+          done();
+        };
+
+        doc().addEventListener('ajax:complete', handler);
+
+        click(submit);
+
+        expect(submitForm.called).to.be.true;
+      });
+
       it('is sent as XHR request', function (done) {
         var url = win().location.href;
         

--- a/test/method.spec.js
+++ b/test/method.spec.js
@@ -64,6 +64,34 @@ describe('Link methods', function () {
         a.setAttribute('data-remote', 'true');
       });
 
+      it('calls ajax:before event on a element with bubbling enabled', function (done) {
+        var handler = function (event) {
+          expect(event.target).to.equal(a);
+          expect(event.bubbles).to.equal(true);
+
+          doc().removeEventListener('ajax:before', handler);
+          done();
+        };
+
+        doc().addEventListener('ajax:before', handler);
+
+        click(a);
+      });
+
+      it('calls ajax:complete event on a element with bubbling enabled', function (done) {
+        var handler = function (event) {
+          expect(event.target).to.equal(a);
+          expect(event.bubbles).to.equal(true);
+
+          doc().removeEventListener('ajax:complete', handler);
+          done();
+        };
+
+        doc().addEventListener('ajax:complete', handler);
+
+        click(a);
+      });
+
       it('is sent as XHR request', function (done) {
         var url = win().location.href;
 


### PR DESCRIPTION
I added target support for LiteAjax. So, `ajax:before` and `ajax:complete` events is triggered upon actual form/a elements with bubbling enabled. This is on par with jquery-ujs.