### PR TITLE
Append the `confirm.js` file before `method.js`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,8 +26,8 @@ module.exports = function (grunt) {
         src: [
           'lib/assets/javascripts/vanilla-ujs/polyfills.js',
           'lib/assets/javascripts/vanilla-ujs/liteajax.js',
-          'lib/assets/javascripts/vanilla-ujs/method.js',
           'lib/assets/javascripts/vanilla-ujs/confirm.js',
+          'lib/assets/javascripts/vanilla-ujs/method.js',
           'lib/assets/javascripts/vanilla-ujs/disable.js',
           'lib/assets/javascripts/vanilla-ujs/csrf.js',
           'lib/assets/javascripts/vanilla-ujs/form.js',


### PR DESCRIPTION
This fixes an issue if both `confirm` and `method` are used on a link. Before the fix, the method event is called first and the propagation is not stopped by cancelling the confirm dialog.