### PR TITLE
Do not send FormData when it is empty

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/form.js
+++ b/lib/assets/javascripts/vanilla-ujs/form.js
@@ -1,3 +1,27 @@
+var VanillaUJS = {
+  formHasNoInputs: function (form) {
+    var element,
+        fieldType;
+
+    for (var i = 0, elements = form.elements, count = elements.length; i < count; i++) {
+      element = elements[i];
+      fieldType = element.nodeName.toUpperCase();
+
+      if (!element.hasAttribute('name') || element.disabled) {
+        continue;
+      }
+
+      if ((fieldType == 'RADIO' || fieldType == 'CHECKBOX') && !element.checked) {
+        continue;
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+};
+
 document.addEventListener('submit', function(event) {
 
   var form = event.target;
@@ -6,9 +30,12 @@ document.addEventListener('submit', function(event) {
     var url = form.action;
     var method = (form.method || form.getAttribute('data-method') || 'POST').toUpperCase();
     var data = new FormData(form);
+    var formHasNoInputs = VanillaUJS.formHasNoInputs(form);
 
     if (CSRF.param() && CSRF.token()) {
       data[CSRF.param()] = CSRF.token();
+    } else if (formHasNoInputs) {
+      data = null;
     }
 
     if (LiteAjax.ajax({ url: url, method: method, data: data, target: form })){

--- a/test/form.spec.js
+++ b/test/form.spec.js
@@ -100,6 +100,21 @@ describe('Form methods', function () {
 
         expect(submitForm.called).to.be.true;
       });
+
+      it('does not pass formdata when there are no form inputs', function (done) {
+        // Inputs without name are usually not included in a form POST, we use that to simulate
+        // a request without inputs
+        submit.removeAttribute('name');
+
+        win().LiteAjax.ajax = sinon.spy();
+        click(submit);
+
+        var options = win().LiteAjax.ajax.getCall(0).args[0];
+        expect(options.data).to.equal(null);
+
+        expect(submitForm.called).to.be.true;
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Fix for hauleth/vanilla-ujs #28. For the full bug report please refer to
https://github.com/hauleth/vanilla-ujs/issues/28.

Basically, when creating a FormData object from a form that has no
inputs to be sent (inputs that are disabled, inputs without name and
unchecked checkboxes/radio buttons are generally not included in a form
request) and sending that as the body for a XMLHttpRequest, it will
result in a corrupt multipart request. Unfortunately there is poor support for
iterating a FormData object to find out if it is empty (at least it did
not work in PhantomJS).

This fix tries to predict if the FormData object will be empty by
inspecting the form elements. If it can find no form input that will be
included in the request, the data is nullified before passing it to
`LiteAjax.ajax()`.