### PR TITLE
eval() xhr response of type application/javascript as well

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/liteajax.js
+++ b/lib/assets/javascripts/vanilla-ujs/liteajax.js
@@ -26,7 +26,7 @@ var LiteAjax = (function () {
 
     xhr.addEventListener('load', function () {
       var responseType = xhr.getResponseHeader('content-type');
-      if(responseType === 'text/javascript; charset=utf-8') {
+      if(/(application|text)\/javascript/i.test(responseType)) {
         eval(xhr.response);
       }
 


### PR DESCRIPTION
limiting execution of xhr responses to the content type `text/javascript` does not make much sense, i think.

meanwhile, everybody else can use this as part of you application code:

```js
document.addEventListener("ajax:complete", function(e) {
  var xhr = e.detail;
  var responseType = xhr.getResponseHeader('content-type');
  if(responseType === 'text/javascript; charset=utf-8') {
    return;
  }
  if (/(application|text)\/javascript/i.test(responseType)) {
    eval(xhr.response);
  }
});
```